### PR TITLE
Add Three.js (Vite or Next) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ By creating a `.cursorrules` file in your project's root directory, you can leve
 - [SvelteKit (RESTful API, Tailwind CSS)](./rules/sveltekit-restful-api-tailwind-css-cursorrules-pro/.cursorrules)
 - [SvelteKit (Tailwind CSS, TypeScript)](./rules/sveltekit-tailwindcss-typescript-cursorrules-promp/.cursorrules)
 - [SvelteKit (TypeScript Guide)](./rules/sveltekit-typescript-guide-cursorrules-prompt-file/.cursorrules)
+- [Three.js (Vite or Next)](./rules/three-vite-or-next-cursorrules-prompt-file/.cursorrules)
 - [Vue 3 (Nuxt 3 Development)](./rules/vue-3-nuxt-3-development-cursorrules-prompt-file/.cursorrules)
 - [Vue 3 (Nuxt 3, TypeScript)](./rules/vue-3-nuxt-3-typescript-cursorrules-prompt-file/.cursorrules)
 - [Vue 3 (Composition API)](./rules/vue3-composition-api-cursorrules-prompt-file/.cursorrules)

--- a/rules/three-vite-or-next-cursorrules-prompt-file/.cursorrules
+++ b/rules/three-vite-or-next-cursorrules-prompt-file/.cursorrules
@@ -1,0 +1,1 @@
+ok so create a simple web page that can run in thre from vite or next


### PR DESCRIPTION
This pull request adds a new entry for Three.js (Vite or Next) to the README file. This addition provides users with a reference to the corresponding `.cursorrules` file, enhancing the documentation and making it easier for developers to find relevant resources for using Three.js with Vite or Next frameworks.